### PR TITLE
ref: remove panics from client and client set and user logger.Panic

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"github.com/kotalco/api/pkg/configs"
+	"github.com/kotalco/api/pkg/logger"
 	chainlinkv1alpha1 "github.com/kotalco/kotal/apis/chainlink/v1alpha1"
 	ethereumv1alpha1 "github.com/kotalco/kotal/apis/ethereum/v1alpha1"
 	ethereum2v1alpha1 "github.com/kotalco/kotal/apis/ethereum2/v1alpha1"
@@ -26,8 +27,7 @@ func Client() client.Client {
 	clientOnce.Do(func() {
 		controllerRuntimeClient, err = NewRuntimeClient()
 		if err != nil {
-			// TODO: Don't panic
-			panic(err)
+			logger.Panic("K8S_CLIENT", err)
 		}
 	})
 	return controllerRuntimeClient

--- a/pkg/k8s/client_set.go
+++ b/pkg/k8s/client_set.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"github.com/kotalco/api/pkg/configs"
+	"github.com/kotalco/api/pkg/logger"
 	"k8s.io/client-go/kubernetes"
 	"sync"
 )
@@ -15,8 +16,7 @@ func Clientset() *kubernetes.Clientset {
 	clientsetOnce.Do(func() {
 		KubernetesClientset, err = NewClientset()
 		if err != nil {
-			// TODO: Don't panic
-			panic(err)
+			logger.Panic("K8S_CLIENT_SET", err)
 		}
 	})
 	return KubernetesClientset


### PR DESCRIPTION
The panics inside the k8 client and client  throws if we tried to start or test the application without kind running in the background .
eg: github test pipeline

